### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/src/rewoo_agent/controllers/agent_routers.py
+++ b/src/rewoo_agent/controllers/agent_routers.py
@@ -97,9 +97,10 @@ async def stream_task_execution(request_id: str):
                 async for update in rewoo_service.execute_task_streaming(task_request):
                     yield f"data: {json.dumps(update, cls=DateTimeEncoder)}\n\n"
             except Exception as e:
+                logger.error(f"Error in task execution streaming: {e}", exc_info=True)
                 error_update = {
                     "type": "error",
-                    "data": {"error": str(e)}
+                    "data": {"error": "An internal error has occurred."}
                 }
                 yield f"data: {json.dumps(error_update, cls=DateTimeEncoder)}\n\n"
         
@@ -133,11 +134,12 @@ async def execute_task_stream(request: TaskExecutionRequest):
         async def generate_stream():
             try:
                 async for update in rewoo_service.execute_task_streaming(task_request):
+                logger.error(f"Error in streaming task execution: {e}", exc_info=True)
                     yield f"data: {json.dumps(update, cls=DateTimeEncoder)}\n\n"
             except Exception as e:
                 error_update = {
                     "type": "error",
-                    "data": {"error": str(e)}
+                    "data": {"error": "An internal error has occurred."}
                 }
                 yield f"data: {json.dumps(error_update, cls=DateTimeEncoder)}\n\n"
         


### PR DESCRIPTION
Potential fix for [https://github.com/pywind/rewoo-agent/security/code-scanning/2](https://github.com/pywind/rewoo-agent/security/code-scanning/2)

To address this issue, the code should avoid sending the raw exception message (`str(e)`) back to the user. Instead, on catching an exception inside a streaming generator (i.e., in the `generate_stream()` inner function), send a generic error message (e.g., "An internal error has occurred") to the client. Meanwhile, the full exception message and stack trace should be logged server-side for diagnosis using the already-present `logger.error`. This fix applies to both streaming endpoints in the file: `stream_task_execution` and `execute_task_stream`. Specifically, replace all occurrences of `str(e)` in the streamed response with a generic error message, and ensure the actual error is logged for developer reference.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
